### PR TITLE
Simplified use of C type by adding use commands

### DIFF
--- a/src/xbee.rs
+++ b/src/xbee.rs
@@ -11,8 +11,11 @@ extern crate va_list;
 
 use libc::time_t;
 use libc::timespec;
+use std::os::raw::*;
+use std::mem::*;
+use std::option::Option;
+use std::default::Default;
 use va_list::VaList;
-//use std::fs::File;
 use libc::FILE;
 
 pub enum Struct_xbee { }
@@ -27,52 +30,46 @@ pub enum Enum_xbee_conSleepStates {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Struct_xbee_conAddress {
-    pub broadcast: ::std::os::raw::c_uchar,
-    pub addr16_enabled: ::std::os::raw::c_uchar,
-    pub addr16: [::std::os::raw::c_uchar; 2usize],
-    pub addr64_enabled: ::std::os::raw::c_uchar,
-    pub addr64: [::std::os::raw::c_uchar; 8usize],
-    pub endpoints_enabled: ::std::os::raw::c_uchar,
-    pub endpoint_local: ::std::os::raw::c_uchar,
-    pub endpoint_remote: ::std::os::raw::c_uchar,
-    pub profile_enabled: ::std::os::raw::c_uchar,
-    pub profile_id: ::std::os::raw::c_ushort,
-    pub cluster_enabled: ::std::os::raw::c_uchar,
-    pub cluster_id: ::std::os::raw::c_ushort,
+    pub broadcast: c_uchar,
+    pub addr16_enabled: c_uchar,
+    pub addr16: [c_uchar; 2usize],
+    pub addr64_enabled: c_uchar,
+    pub addr64: [c_uchar; 8usize],
+    pub endpoints_enabled: c_uchar,
+    pub endpoint_local: c_uchar,
+    pub endpoint_remote: c_uchar,
+    pub profile_enabled: c_uchar,
+    pub profile_id: c_ushort,
+    pub cluster_enabled: c_uchar,
+    pub cluster_id: c_ushort,
 }
-/*impl ::std::clone::Clone for Struct_xbee_conAddress {
-    fn clone(&self) -> Self { *self }
-}*/
-impl ::std::default::Default for Struct_xbee_conAddress {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+
+impl Default for Struct_xbee_conAddress {
+    fn default() -> Self { unsafe { zeroed() } }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 #[allow(non_snake_case)]
 pub struct Struct_xbee_conInfo {
-    pub countRx: ::std::os::raw::c_int,
-    pub countTx: ::std::os::raw::c_int,
+    pub countRx: c_int,
+    pub countTx: c_int,
     pub lastRxTime: time_t,
 }
-/*impl ::std::clone::Clone for Struct_xbee_conInfo {
-    fn clone(&self) -> Self { *self }
-}*/
-impl ::std::default::Default for Struct_xbee_conInfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+
+impl Default for Struct_xbee_conInfo {
+    fn default() -> Self { unsafe { zeroed() } }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 #[allow(non_snake_case)]
 pub struct Struct_xbee_conSettings {
-    pub _bindgen_bitfield_1_: ::std::os::raw::c_uchar,
-    pub _bindgen_bitfield_2_: ::std::os::raw::c_uchar,
-    pub broadcastRadius: ::std::os::raw::c_uchar,
+    pub _bindgen_bitfield_1_: c_uchar,
+    pub _bindgen_bitfield_2_: c_uchar,
+    pub broadcastRadius: c_uchar,
 }
-/*impl ::std::clone::Clone for Struct_xbee_conSettings {
-    fn clone(&self) -> Self { *self }
-}*/
-impl ::std::default::Default for Struct_xbee_conSettings {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+
+impl Default for Struct_xbee_conSettings {
+    fn default() -> Self { unsafe { zeroed() } }
 }
 pub enum Struct_xbee_ll_head { }
 #[repr(C)]
@@ -81,24 +78,22 @@ pub enum Struct_xbee_ll_head { }
 pub struct Struct_xbee_pkt {
     pub xbee: *mut Struct_xbee,
     pub con: *mut Struct_xbee_con,
-    pub conType: *const ::std::os::raw::c_char,
-    pub status: ::std::os::raw::c_uchar,
-    pub options: ::std::os::raw::c_uchar,
-    pub rssi: ::std::os::raw::c_uchar,
-    pub apiIdentifier: ::std::os::raw::c_uchar,
-    pub frameId: ::std::os::raw::c_uchar,
+    pub conType: *const c_char,
+    pub status: c_uchar,
+    pub options: c_uchar,
+    pub rssi: c_uchar,
+    pub apiIdentifier: c_uchar,
+    pub frameId: c_uchar,
     pub timestamp: timespec,
     pub address: Struct_xbee_conAddress,
-    pub atCommand: [::std::os::raw::c_uchar; 2usize],
+    pub atCommand: [c_uchar; 2usize],
     pub dataItems: *mut Struct_xbee_ll_head,
-    pub dataLen: ::std::os::raw::c_int,
-    pub data: [::std::os::raw::c_uchar; 1usize],
+    pub dataLen: c_int,
+    pub data: [c_uchar; 1usize],
 }
-/*impl ::std::clone::Clone for Struct_xbee_pkt {
-    fn clone(&self) -> Self { *self }
-}*/
-impl ::std::default::Default for Struct_xbee_pkt {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+
+impl Default for Struct_xbee_pkt {
+    fn default() -> Self { unsafe { zeroed() } }
 }
 #[derive(Clone, Copy)]
 #[repr(i32)]
@@ -136,49 +131,43 @@ pub enum Enum_xbee_errors {
 }
 pub type xbee_err = Enum_xbee_errors;
 pub type xbee_t_eofCallback =
-    ::std::option::Option<unsafe extern "C" fn(xbee: *mut Struct_xbee,
+    Option<unsafe extern "C" fn(xbee: *mut Struct_xbee,
                                                rxInfo:
-                                                   *mut ::std::os::raw::c_void)>;
+                                                   *mut c_void)>;
 pub type xbee_t_conCallback =
-    ::std::option::Option<unsafe extern "C" fn(xbee: *mut Struct_xbee,
+    Option<unsafe extern "C" fn(xbee: *mut Struct_xbee,
                                                con: *mut Struct_xbee_con,
                                                pkt: *mut *mut Struct_xbee_pkt,
                                                data:
-                                                   *mut *mut ::std::os::raw::c_void)>;
+                                                   *mut *mut c_void)>;
 #[link(name = "xbee")]
 extern "C" {
-    pub static mut libxbee_revision: *const ::std::os::raw::c_char;
-    pub static mut libxbee_commit: *const ::std::os::raw::c_char;
-    pub static mut libxbee_committer: *const ::std::os::raw::c_char;
-    pub static mut libxbee_buildtime: *const ::std::os::raw::c_char;
+    pub static mut libxbee_revision: *const c_char;
+    pub static mut libxbee_commit: *const c_char;
+    pub static mut libxbee_committer: *const c_char;
+    pub static mut libxbee_buildtime: *const c_char;
 }
 #[link(name = "xbee")]
 extern "C" {
-    pub fn xbee_freeMemory(ptr: *mut ::std::os::raw::c_void);
+    pub fn xbee_freeMemory(ptr: *mut c_void);
     pub fn xbee_validate(xbee: *mut Struct_xbee) -> xbee_err;
     pub fn xbee_setup(retXbee: *mut *mut Struct_xbee,
-                      mode: *const ::std::os::raw::c_char, ...) -> xbee_err;
+                      mode: *const c_char, ...) -> xbee_err;
     pub fn xbee_vsetup(retXbee: *mut *mut Struct_xbee,
-                       mode: *const ::std::os::raw::c_char, ap: VaList)
-     -> xbee_err;
+                       mode: *const c_char, ap: VaList) -> xbee_err;
     pub fn xbee_attachEOFCallback(xbee: *mut Struct_xbee,
-                                  eofCallback: xbee_t_eofCallback)
-     -> xbee_err;
+                                  eofCallback: xbee_t_eofCallback) -> xbee_err;
     pub fn xbee_shutdown(xbee: *mut Struct_xbee) -> xbee_err;
     pub fn xbee_dataSet(xbee: *mut Struct_xbee,
-                        newData: *mut ::std::os::raw::c_void,
-                        oldData: *mut *mut ::std::os::raw::c_void)
-     -> xbee_err;
+                        newData: *mut c_void,
+                        oldData: *mut *mut c_void) -> xbee_err;
     pub fn xbee_dataGet(xbee: *mut Struct_xbee,
-                        curData: *mut *mut ::std::os::raw::c_void)
-     -> xbee_err;
-    pub fn xbee_modeGetList(retList: *mut *mut *mut ::std::os::raw::c_char)
-     -> xbee_err;
+                        curData: *mut *mut c_void) -> xbee_err;
+    pub fn xbee_modeGetList(retList: *mut *mut *mut c_char) -> xbee_err;
     pub fn xbee_modeGet(xbee: *mut Struct_xbee,
-                        mode: *mut *const ::std::os::raw::c_char) -> xbee_err;
+                        mode: *mut *const c_char) -> xbee_err;
     pub fn xbee_conGetTypes(xbee: *mut Struct_xbee,
-                            retList: *mut *mut *mut ::std::os::raw::c_char)
-     -> xbee_err;
+                            retList: *mut *mut *mut c_char) -> xbee_err;
     pub fn xbee_conNew(xbee: *mut Struct_xbee,
                        retCon: *mut *mut Struct_xbee_con,
                        _type: *const ::std::os::raw::c_char,
@@ -187,129 +176,106 @@ extern "C" {
     pub fn xbee_conGetXBee(con: *mut Struct_xbee_con,
                            xbee: *mut *mut Struct_xbee) -> xbee_err;
     pub fn xbee_conTx(con: *mut Struct_xbee_con,
-                      retVal: *mut ::std::os::raw::c_uchar,
-                      format: *const ::std::os::raw::c_char, ...) -> xbee_err;
+                      retVal: *mut c_uchar,
+                      format: *const c_char, ...) -> xbee_err;
     pub fn xbee_convTx(con: *mut Struct_xbee_con,
-                       retVal: *mut ::std::os::raw::c_uchar,
-                       format: *const ::std::os::raw::c_char, args: VaList)
-     -> xbee_err;
+                       retVal: *mut c_uchar,
+                       format: *const c_char, args: VaList) -> xbee_err;
     pub fn xbee_connTx(con: *mut Struct_xbee_con,
-                       retVal: *mut ::std::os::raw::c_uchar,
-                       buf: *const ::std::os::raw::c_uchar,
-                       len: ::std::os::raw::c_int) -> xbee_err;
+                       retVal: *mut c_uchar,
+                       buf: *const c_uchar,
+                       len: c_int) -> xbee_err;
     pub fn xbee_conxTx(con: *mut Struct_xbee_con,
-                       retVal: *mut ::std::os::raw::c_uchar,
-                       frameId: *mut ::std::os::raw::c_uchar,
-                       format: *const ::std::os::raw::c_char, ...)
-     -> xbee_err;
+                       retVal: *mut c_uchar,
+                       frameId: *mut c_uchar,
+                       format: *const c_char, ...) -> xbee_err;
     pub fn xbee_convxTx(con: *mut Struct_xbee_con,
-                        retVal: *mut ::std::os::raw::c_uchar,
-                        frameId: *mut ::std::os::raw::c_uchar,
-                        format: *const ::std::os::raw::c_char, args: VaList)
-     -> xbee_err;
+                        retVal: *mut c_uchar,
+                        frameId: *mut c_uchar,
+                        format: *const c_char, args: VaList) -> xbee_err;
     pub fn xbee_connxTx(con: *mut Struct_xbee_con,
-                        retVal: *mut ::std::os::raw::c_uchar,
-                        frameId: *mut ::std::os::raw::c_uchar,
-                        buf: *const ::std::os::raw::c_uchar,
-                        len: ::std::os::raw::c_int) -> xbee_err;
+                        retVal: *mut c_uchar,
+                        frameId: *mut c_uchar,
+                        buf: *const c_uchar,
+                        len: c_int) -> xbee_err;
     pub fn xbee_conRx(con: *mut Struct_xbee_con,
                       retPkt: *mut *mut Struct_xbee_pkt,
-                      remainingPackets: *mut ::std::os::raw::c_int)
-     -> xbee_err;
+                      remainingPackets: *mut c_int) -> xbee_err;
     pub fn xbee_conRxWait(con: *mut Struct_xbee_con,
                           retPkt: *mut *mut Struct_xbee_pkt,
-                          remainingPackets: *mut ::std::os::raw::c_int)
-     -> xbee_err;
+                          remainingPackets: *mut c_int) -> xbee_err;
     pub fn xbee_conPurge(con: *mut Struct_xbee_con) -> xbee_err;
     pub fn xbee_conSleepSet(con: *mut Struct_xbee_con,
                             state: Enum_xbee_conSleepStates) -> xbee_err;
     pub fn xbee_conSleepGet(con: *mut Struct_xbee_con,
                             state: *mut Enum_xbee_conSleepStates) -> xbee_err;
     pub fn xbee_conDataSet(con: *mut Struct_xbee_con,
-                           newData: *mut ::std::os::raw::c_void,
-                           oldData: *mut *mut ::std::os::raw::c_void)
-     -> xbee_err;
+                           newData: *mut c_void,
+                           oldData: *mut *mut c_void) -> xbee_err;
     pub fn xbee_conDataGet(con: *mut Struct_xbee_con,
-                           curData: *mut *mut ::std::os::raw::c_void)
-     -> xbee_err;
+                           curData: *mut *mut c_void) -> xbee_err;
     pub fn xbee_conTypeGet(con: *mut Struct_xbee_con,
-                           _type: *mut *mut ::std::os::raw::c_char)
-     -> xbee_err;
+                           _type: *mut *mut c_char) -> xbee_err;
     pub fn xbee_conInfoGet(con: *mut Struct_xbee_con,
                            info: *mut Struct_xbee_conInfo) -> xbee_err;
     pub fn xbee_conCallbackSet(con: *mut Struct_xbee_con,
                                newCallback: xbee_t_conCallback,
-                               oldCallback: *mut xbee_t_conCallback)
-     -> xbee_err;
+                               oldCallback: *mut xbee_t_conCallback) -> xbee_err;
     pub fn xbee_conCallbackGet(con: *mut Struct_xbee_con,
-                               curCallback: *mut xbee_t_conCallback)
-     -> xbee_err;
+                               curCallback: *mut xbee_t_conCallback) -> xbee_err;
     pub fn xbee_conSettings(con: *mut Struct_xbee_con,
                             newSettings: *mut Struct_xbee_conSettings,
-                            oldSettings: *mut Struct_xbee_conSettings)
-     -> xbee_err;
+                            oldSettings: *mut Struct_xbee_conSettings) -> xbee_err;
     pub fn xbee_conEnd(con: *mut Struct_xbee_con) -> xbee_err;
     pub fn xbee_pktFree(pkt: *mut Struct_xbee_pkt) -> xbee_err;
     pub fn xbee_pktValidate(pkt: *mut Struct_xbee_pkt) -> xbee_err;
     pub fn xbee_pktDataGet(pkt: *mut Struct_xbee_pkt,
-                           key: *const ::std::os::raw::c_char,
-                           id: ::std::os::raw::c_int,
-                           index: ::std::os::raw::c_int,
-                           retData: *mut *mut ::std::os::raw::c_void)
-     -> xbee_err;
+                           key: *const c_char,
+                           id: c_int,
+                           index: c_int,
+                           retData: *mut *mut c_void) -> xbee_err;
     pub fn xbee_pktAnalogGet(pkt: *mut Struct_xbee_pkt,
-                             channel: ::std::os::raw::c_int,
-                             index: ::std::os::raw::c_int,
-                             retVal: *mut ::std::os::raw::c_int) -> xbee_err;
+                             channel: c_int,
+                             index: c_int,
+                             retVal: *mut c_int) -> xbee_err;
     pub fn xbee_pktDigitalGet(pkt: *mut Struct_xbee_pkt,
-                              channel: ::std::os::raw::c_int,
-                              index: ::std::os::raw::c_int,
-                              retVal: *mut ::std::os::raw::c_int) -> xbee_err;
-    pub fn xbee_netStart(xbee: *mut Struct_xbee, port: ::std::os::raw::c_int,
+                              channel: c_int,
+                              index: c_int,
+                              retVal: *mut c_int) -> xbee_err;
+    pub fn xbee_netStart(xbee: *mut Struct_xbee, port: c_int,
                          clientFilter:
-                             ::std::option::Option<unsafe extern "C" fn(xbee:
-                                                                            *mut Struct_xbee,
-                                                                        remoteHost:
-                                                                            *const ::std::os::raw::c_char)
-                                                       ->
-                                                           ::std::os::raw::c_int>)
-     -> xbee_err;
-    pub fn xbee_netvStart(xbee: *mut Struct_xbee, fd: ::std::os::raw::c_int,
+                             Option<unsafe extern "C" fn(xbee: *mut Struct_xbee,
+                                                         remoteHost: *const c_char)
+                                                         -> c_int>) -> xbee_err;
+    pub fn xbee_netvStart(xbee: *mut Struct_xbee, fd: c_int,
                           clientFilter:
-                              ::std::option::Option<unsafe extern "C" fn(xbee:
-                                                                             *mut Struct_xbee,
-                                                                         remoteHost:
-                                                                             *const ::std::os::raw::c_char)
-                                                        ->
-                                                            ::std::os::raw::c_int>)
-     -> xbee_err;
+                              Option<unsafe extern "C" fn(xbee: *mut Struct_xbee,
+                                                          remoteHost: *const c_char)
+                                                         -> c_int>) -> xbee_err;
     pub fn xbee_netStop(xbee: *mut Struct_xbee) -> xbee_err;
-    pub fn xbee_logTargetSet(xbee: *mut Struct_xbee, f: *mut FILE)
-     -> xbee_err;
-    pub fn xbee_logTargetGet(xbee: *mut Struct_xbee, f: *mut *mut FILE)
-     -> xbee_err;
+    pub fn xbee_logTargetSet(xbee: *mut Struct_xbee, f: *mut FILE) -> xbee_err;
+    pub fn xbee_logTargetGet(xbee: *mut Struct_xbee, f: *mut *mut FILE) -> xbee_err;
     pub fn xbee_logLevelSet(xbee: *mut Struct_xbee,
-                            level: ::std::os::raw::c_int) -> xbee_err;
+                            level: c_int) -> xbee_err;
     pub fn xbee_logLevelGet(xbee: *mut Struct_xbee,
-                            level: *mut ::std::os::raw::c_int) -> xbee_err;
+                            level: *mut c_int) -> xbee_err;
     pub fn xbee_logRxSet(xbee: *mut Struct_xbee,
-                         enable: ::std::os::raw::c_int) -> xbee_err;
+                         enable: c_int) -> xbee_err;
     pub fn xbee_logRxGet(xbee: *mut Struct_xbee,
-                         enabled: *mut ::std::os::raw::c_int) -> xbee_err;
+                         enabled: *mut c_int) -> xbee_err;
     pub fn xbee_logTxSet(xbee: *mut Struct_xbee,
-                         enable: ::std::os::raw::c_int) -> xbee_err;
+                         enable: c_int) -> xbee_err;
     pub fn xbee_logTxGet(xbee: *mut Struct_xbee,
-                         enabled: *mut ::std::os::raw::c_int) -> xbee_err;
+                         enabled: *mut c_int) -> xbee_err;
     pub fn xbee_logColorSet(xbee: *mut Struct_xbee,
-                            enable: ::std::os::raw::c_int) -> xbee_err;
+                            enable: c_int) -> xbee_err;
     pub fn xbee_logColorGet(xbee: *mut Struct_xbee,
-                            enabled: *mut ::std::os::raw::c_int) -> xbee_err;
-    pub fn _xbee_logDev(file: *const ::std::os::raw::c_char,
-                        line: ::std::os::raw::c_int,
-                        function: *const ::std::os::raw::c_char,
+                            enabled: *mut c_int) -> xbee_err;
+    pub fn _xbee_logDev(file: *const c_char,
+                        line: c_int,
+                        function: *const c_char,
                         xbee: *mut Struct_xbee,
-                        minLevel: ::std::os::raw::c_int,
-                        format: *const ::std::os::raw::c_char, ...)
-     -> xbee_err;
-    pub fn xbee_errorToStr(error: xbee_err) -> *const ::std::os::raw::c_char;
+                        minLevel: c_int,
+                        format: *const c_char, ...) -> xbee_err;
+    pub fn xbee_errorToStr(error: xbee_err) -> *const c_char;
 }


### PR DESCRIPTION
Simplified the use of C types by adding the uses below and modifying the related code
use std::os::raw::_;
use std::mem::_;
use std::option::Option;
use std::default::Default;
